### PR TITLE
 Fix ExecutorService not correctly shutdown

### DIFF
--- a/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java
@@ -544,7 +544,7 @@ public class FFTConvolution< R extends RealType< R > >
 		// inverse FFT in place
 		FFT.complexToRealUnpad( fftconvolved, output, s );
 		
-		if ( service == null ) { 
+		if ( service != null ) { 
 			// shutdown own self created service
 			s.shutdown();
 		}


### PR DESCRIPTION
 Fix ExecutorService not correctly shutdown at the end of FFTConvolution.convolve().

See https://github.com/imglib/imglib2-algorithm-gpl/blob/master/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java#L547

and the related bug in Trackmate : https://github.com/fiji/TrackMate/issues/59