### PR TITLE
Revert Fix ExecutorService not correctly shutdown

### DIFF
--- a/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java
@@ -544,7 +544,7 @@ public class FFTConvolution< R extends RealType< R > >
 		// inverse FFT in place
 		FFT.complexToRealUnpad( fftconvolved, output, s );
 		
-		if ( service != null ) { 
+		if ( service == null ) { 
 			// shutdown own self created service
 			s.shutdown();
 		}


### PR DESCRIPTION
See #3 for the reason why we revert this PR.