### PR TITLE
Fixes a bug in FFTConvolution that by default calculated correlation

### DIFF
--- a/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java
+++ b/src/main/java/net/imglib2/algorithm/fft2/FFTConvolution.java
@@ -91,8 +91,9 @@ public class FFTConvolution< R extends RealType< R > >
 
 	RandomAccessibleInterval< R > output;
 
-	// by default we use the complex conjugate of the kernel
-	boolean complexConjugate = true;
+	// convolution: complexConjugate = false	
+	// correlation: complexConjugate = true 
+	boolean complexConjugate = false;
 
 	// by default we do not keep the image
 	boolean keepImgFFT = false;
@@ -524,9 +525,9 @@ public class FFTConvolution< R extends RealType< R > >
 		{
 			fftKernel = FFT.realToComplex( kernelInput, fftFactory, s );
 
-			// compute the complex conjugate of the FFT of the kernel (same as
-			// mirroring the input image)
-			// otherwise it corresponds to correlation and not convolution
+			// if complexConjugate is set we are computing the correlation  
+			// instead of the convolution (same as mirroring the kernel)
+			// should be false by default
 			if ( complexConjugate )
 				FFTMethods.complexConjugate( fftKernel );
 		}

--- a/src/test/java/net/imglib2/algorithm/fft2/FFTConvolutionTest.java
+++ b/src/test/java/net/imglib2/algorithm/fft2/FFTConvolutionTest.java
@@ -1,0 +1,58 @@
+package net.imglib2.algorithm.fft2;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+import net.imglib2.Cursor;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.FloatType;
+
+public class FFTConvolutionTest {
+
+	
+	@Test
+	public void test_1d() throws IncompatibleTypeException {
+		
+		final int n_image = 33;
+		final int n_kernel = 32;
+		
+		float[] arr_image = new float[n_image];
+		arr_image[n_image/2] = 1;
+		
+		float[] arr_kernel = new float[n_kernel];
+		Random r = new Random();
+		for (int i = 0; i < arr_kernel.length; i++) {
+			arr_kernel[i] = r.nextFloat();	
+		}
+		
+		final Img< FloatType > image = ArrayImgs.floats(arr_image, n_image);
+		final Img< FloatType > kernel = ArrayImgs.floats(arr_kernel, n_kernel);
+		final Img< FloatType > result = ArrayImgs.floats(new float[n_image], n_image);
+		
+		final FFTConvolution< FloatType > conv = new FFTConvolution<FloatType>( image, kernel, result );
+		conv.setComputeComplexConjugate(false);
+		
+		conv.convolve();
+		
+		assertImagesEqual(kernel,result, 0.0001f);
+		
+	}
+	protected void assertImagesEqual(Img<FloatType> img1, Img<FloatType> img2,
+			float delta)
+		{
+			Cursor<FloatType> c1 = img1.cursor();
+			Cursor<FloatType> c2 = img2.cursor();
+			while (c1.hasNext()) {
+				c1.fwd();
+				c2.fwd();
+				
+				assertEquals(c1.get().getRealFloat(), c2.get().getRealFloat(), delta);
+			}
+
+		}
+}


### PR DESCRIPTION
instead of convolution (which is the same for mirror symmetric kernels)
Convolution is now the default.

Added simple 1d test of that.